### PR TITLE
Change signing interface to return promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/key/Key.ts
+++ b/src/key/Key.ts
@@ -49,7 +49,7 @@ export abstract class Key {
    *
    * @param payload the data to be signed
    */
-  public abstract sign(payload: Buffer): Buffer;
+  public abstract sign(payload: Buffer): Promise<Buffer>;
 
   /**
    * Terra account address. `terra-` prefixed.
@@ -91,8 +91,8 @@ export abstract class Key {
    *
    * @param tx sign-message of the transaction to sign
    */
-  public createSignature(tx: StdSignMsg): StdSignature {
-    const sigData = this.sign(Buffer.from(tx.toJSON()));
+  public async createSignature(tx: StdSignMsg): Promise<StdSignature> {
+    const sigData = await this.sign(Buffer.from(tx.toJSON()));
     return StdSignature.fromData({
       signature: sigData.toString('base64'),
       pub_key: {
@@ -106,8 +106,8 @@ export abstract class Key {
    * Signs a [[StdSignMsg]] and adds the signature to a generated StdTx that is ready to be broadcasted.
    * @param tx
    */
-  public signTx(tx: StdSignMsg): StdTx {
-    const sig = this.createSignature(tx);
+  public async signTx(tx: StdSignMsg): Promise<StdTx> {
+    const sig = await this.createSignature(tx);
     return new StdTx(tx.msgs, tx.fee, [sig], tx.memo);
   }
 }

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -103,7 +103,7 @@ export class MnemonicKey extends Key {
     this.mnemonic = mnemonic;
   }
 
-  public sign(payload: Buffer): Buffer {
+  public async sign(payload: Buffer): Promise<Buffer> {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
     const { signature } = secp256k1.ecdsaSign(
       Uint8Array.from(hash),

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -20,7 +20,7 @@ export class RawKey extends Key {
     this.privateKey = privateKey;
   }
 
-  public sign(payload: Buffer): Buffer {
+  public async sign(payload: Buffer): Promise<Buffer> {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
     const { signature } = secp256k1.ecdsaSign(
       Uint8Array.from(hash),


### PR DESCRIPTION
To allow for async signing, for example over a network, the signing
function is changed to return a promise