### PR TITLE
Change contstructors to use Coins.Input instead of Coins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/distribution/proposals/CommunityPoolSpendProposal.ts
+++ b/src/core/distribution/proposals/CommunityPoolSpendProposal.ts
@@ -9,6 +9,7 @@ import { AccAddress } from '../../strings';
 export class CommunityPoolSpendProposal extends JSONSerializable<
   CommunityPoolSpendProposal.Data
 > {
+  public amount: Coins;
   /**
    * @param title proposal's title
    * @param description proposal's description
@@ -19,9 +20,10 @@ export class CommunityPoolSpendProposal extends JSONSerializable<
     public title: string,
     public description: string,
     public recipient: AccAddress,
-    public amount: Coins
+    amount: Coins.Input
   ) {
     super();
+    this.amount = new Coins(amount);
   }
 
   public static fromData(

--- a/src/core/gov/msgs/MsgDeposit.ts
+++ b/src/core/gov/msgs/MsgDeposit.ts
@@ -6,6 +6,7 @@ import { AccAddress } from '../../strings';
  * Add a deposit for a proposal
  */
 export class MsgDeposit extends JSONSerializable<MsgDeposit.Data> {
+  public amount: Coins;
   /**
    * @param proposal_id Id of porposal to deposit to
    * @param depositor depositor's account address
@@ -14,9 +15,10 @@ export class MsgDeposit extends JSONSerializable<MsgDeposit.Data> {
   constructor(
     public proposal_id: number,
     public depositor: AccAddress,
-    public amount: Coins
+    amount: Coins.Input
   ) {
     super();
+    this.amount = new Coins(amount);
   }
 
   public static fromData(data: MsgDeposit.Data): MsgDeposit {

--- a/src/core/gov/msgs/MsgSubmitProposal.ts
+++ b/src/core/gov/msgs/MsgSubmitProposal.ts
@@ -9,6 +9,8 @@ import { AccAddress } from '../../strings';
 export class MsgSubmitProposal extends JSONSerializable<
   MsgSubmitProposal.Data
 > {
+  public initial_deposit: Coins;
+
   /**
    * @param content proposal content to submit
    * @param initial_deposit deposit provided
@@ -16,10 +18,11 @@ export class MsgSubmitProposal extends JSONSerializable<
    */
   constructor(
     public content: Proposal.Content,
-    public initial_deposit: Coins,
+    initial_deposit: Coins.Input,
     public proposer: AccAddress
   ) {
     super();
+    this.initial_deposit = new Coins(initial_deposit);
   }
 
   public static fromData(data: MsgSubmitProposal.Data): MsgSubmitProposal {

--- a/src/core/msgauth/Authorization.ts
+++ b/src/core/msgauth/Authorization.ts
@@ -49,8 +49,10 @@ export namespace Authorization {
 export class SendAuthorization extends JSONSerializable<
   SendAuthorization.Data
 > {
-  constructor(public spend_limit: Coins) {
+  public spend_limit: Coins;
+  constructor(spend_limit: Coins.Input) {
     super();
+    this.spend_limit = new Coins(spend_limit);
   }
 
   public static fromData(data: SendAuthorization.Data): SendAuthorization {

--- a/src/core/wasm/msgs/MsgExecuteContract.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.ts
@@ -5,6 +5,8 @@ import { Coins } from '../../Coins';
 export class MsgExecuteContract extends JSONSerializable<
   MsgExecuteContract.Data
 > {
+  public coins: Coins;
+
   /**
    * @param sender contract user
    * @param contract contract address
@@ -15,9 +17,10 @@ export class MsgExecuteContract extends JSONSerializable<
     public sender: AccAddress,
     public contract: AccAddress,
     public execute_msg: object,
-    public coins: Coins
+    coins: Coins.Input
   ) {
     super();
+    this.coins = new Coins(coins);
   }
 
   public static fromData(data: MsgExecuteContract.Data): MsgExecuteContract {

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -5,6 +5,8 @@ import { Coins } from '../../Coins';
 export class MsgInstantiateContract extends JSONSerializable<
   MsgInstantiateContract.Data
 > {
+  public init_coins: Coins;
+
   /**
    * @param owner contract owner
    * @param code_id reference to the code on the blockchain
@@ -16,10 +18,11 @@ export class MsgInstantiateContract extends JSONSerializable<
     public owner: AccAddress,
     public code_id: number,
     public init_msg: object,
-    public init_coins: Coins,
+    init_coins: Coins.Input,
     public migratable: boolean
   ) {
     super();
+    this.init_coins = new Coins(init_coins);
   }
 
   public static fromData(


### PR DESCRIPTION
This make it convenient to do the following:

```ts
new MsgInstantiateContract(
    'terra...',
    3,
    { init: msg },
    { ukrw: 1, uluna: 3},
    false
)
```

Instead of:

```ts
new MsgInstantiateContract(
    'terra...',
    3,
    { init: msg },
    new Coins({ ukrw: 1, uluna: 3 }),
    false
)
```

for various classes. The classes changed are:

- CommunityPoolSpendProposal
- MsgInstantiateContract
- MsgExecuteContract
- SendAuthorization
- MsgDeposit
- MsgSubmitProposal

All other core data classes that are expected to be used by end-users already use this convenition, such as MsgSend and MsgMultiSend.