### PR TITLE
Feature: Change fee estimation parameters in Wallet.createTx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3098,9 +3098,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.10",
+  "version": "0.4.11",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
In order to change fee estimation parameters, one had to modify the `LCDClient` that generated the `Wallet` instance:

```ts
const terra = new LCDClient(...);
const mk = new MnemonicKey(...);

const wallet = terra.wallet(mk);
terra.config.gasPrices = ...
terra.config.gasAdjustment = ...

const unsignedTx = await wallet.createTx({
  msgs: [send, swap], 
});
```

This pull requests makes it possible to specify the gas prices and gas adjustment without altering the global LCD configuration for a single instance of fee estimation via `Wallet.createTx`, (which is automatically reflected in `Wallet.createAndSignTx` as well). The optional fields `gasPrices` and `gasAdjustment` can be passed to `createTx` to override the defaults for the `LCDClient`'s fee estimation parameters.

```ts
const terra = new LCDClient(...);
const mk = new MnemonicKey(...);
const wallet = terra.wallet(mk);

const unsignedTx = await wallet.createTx({
  msgs: [send, swap], 
  gasPrices: { ukrw: 0.015 },
  gasAdjustment: 1.9
});

const fee = unsignedTx.fee;
```