### PR TITLE
Fix: Add 'txInfosByHeight' and 'code' to TxInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3098,9 +3098,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.10",
+  "version": "0.4.11",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.11",
+  "version": "0.4.12",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/client/lcd/api/TendermintAPI.ts
+++ b/src/client/lcd/api/TendermintAPI.ts
@@ -32,7 +32,7 @@ export class TendermintAPI extends BaseAPI {
    * Gets the block information at the specified height. If no height is given, the latest block is returned.
    * @param height block height.
    */
-  public async block(height?: number): Promise<BlockInfo> {
+  public async blockInfo(height?: number): Promise<BlockInfo> {
     const url = height !== undefined ? `/blocks/${height}` : `/blocks/latest`;
     return this.c.getRaw<BlockInfo>(url);
   }

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -85,6 +85,22 @@ export class TxAPI extends BaseAPI {
   }
 
   /**
+   * Looks up transactions on the blockchain for the block height. If height is undefined,
+   * gets the transactions for the latest block.
+   * @param height block height
+   */
+  public async txInfosByHeight(height: number | undefined): Promise<TxInfo[]> {
+    const blockInfo = await this.lcd.tendermint.blockInfo(height);
+    const { txs } = blockInfo.block.data;
+    if (!txs) {
+      return [];
+    } else {
+      const txhashes = txs.map(txdata => hashAmino(txdata));
+      return Promise.all(txhashes.map(txhash => this.txInfo(txhash)));
+    }
+  }
+
+  /**
    * Estimates the transaction's fee by simulating it within the node
    * @param tx transaction for which to estimate fee
    * @param options options for fee estimation

--- a/src/core/TxInfo.ts
+++ b/src/core/TxInfo.ts
@@ -17,6 +17,7 @@ export class TxInfo extends JSONSerializable<TxInfo.Data> {
    * @param tx transaction content
    * @param timestamp time of inclusion
    * @param events events
+   * @param code error code
    */
   constructor(
     public height: number,
@@ -27,7 +28,8 @@ export class TxInfo extends JSONSerializable<TxInfo.Data> {
     public gas_used: number,
     public tx: StdTx,
     public timestamp: string,
-    public events: Event[]
+    public events: Event[],
+    public code?: number
   ) {
     super();
   }
@@ -42,7 +44,8 @@ export class TxInfo extends JSONSerializable<TxInfo.Data> {
       Number.parseInt(data.gas_used),
       StdTx.fromData(data.tx),
       data.timestamp,
-      data.events
+      data.events,
+      data.code ? Number.parseInt(data.code) : undefined
     );
   }
 
@@ -57,6 +60,7 @@ export class TxInfo extends JSONSerializable<TxInfo.Data> {
       tx: this.tx.toData(),
       timestamp: this.timestamp,
       events: this.events,
+      code: this.code ? this.code.toString() : undefined,
     };
   }
 }
@@ -89,5 +93,6 @@ export namespace TxInfo {
     tx: StdTx.Data;
     timestamp: string;
     events: Event[];
+    code?: string;
   }
 }

--- a/src/util/hash.ts
+++ b/src/util/hash.ts
@@ -1,22 +1,24 @@
-import SHA256 from 'crypto-js/sha256';
-import CryptoJS from 'crypto-js';
+import * as crypto from 'crypto';
 
+/*
+DEPRECATED (was used by crypto-js)
 function byteArrayToWordArray(ba: Uint8Array): CryptoJS.LibWordArray {
   const wa: number[] = [];
   for (let i = 0; i < ba.length; i += 1) {
     wa[(i / 4) | 0] |= ba[i] << (24 - 8 * i);
   }
-  return CryptoJS.lib.WordArray.create(wa);
-}
+  return crypto.lib.WordArray.create(wa);
+}*/
 
 /**
  * Calculates the transaction hash from Amino-encoded string.
  * @param txData Amino-encoded string (base64)
  */
 export function hashAmino(txData: string): string {
-  const wordArray = byteArrayToWordArray(
-    new Uint8Array(Array.from(Buffer.from(txData, 'base64')))
-  );
-
-  return SHA256(wordArray).toString().toUpperCase();
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.from(txData, 'base64'))
+    .digest('hex')
+    .toString()
+    .toUpperCase();
 }


### PR DESCRIPTION
New function `TxAPI.txInfosByHeight` gives a list of transaction info by block height. 

`TendermintAPI.block(height)` was renamed to `TendermintAPI.blockInfo(height)` to maintain naming consistency with what was being returned. (cf. TxAPI.txInfo)

`TxInfo` was also missing the `code` field as @mesyakim pointed out. This allows for easy checking of a past transaction's failure on the chain.