### PR TITLE
Support for signature and recovery id from ecdsaSign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.17",
+  "version": "0.4.18",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -80,7 +80,7 @@ export class Extension {
    * @return {string}  payload.origin     origin address
    * @return {Msg[]}   payload.msgs       requested msgs
    * @return {boolean} payload.success
-   * @return {string}  payload.result.public_key Hex encoded public key
+   * @return {string}  payload.result.public_key Base64 encoded public key
    * @return {string}  payload.result.signature  Base64 encoded signature
    * @return {number}  payload.result.recid      Recovery id
    */

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,7 +9,7 @@ interface ResponseData {
 type SendDataType = 'connect' | 'post' | 'sign';
 
 interface SignOptions {
-  lcdClientConfig: LCDClientConfig;
+  lcdClientConfig?: LCDClientConfig;
   account_number?: number;
   sequence?: number;
 }
@@ -106,7 +106,7 @@ export class Extension {
    * const stdSignMsg = StdSignMsg.fromData(payload.result.stdSignMsgData);
    * terra.tx.broadcast(new StdTx(stdSignMsg.msgs, stdSignMsg.fee, [sig], stdSignMsg.memo));
    */
-  sign(msgs: Msg[], options: SignOptions): number {
+  sign(msgs: Msg[], options?: SignOptions): number {
     const id = this.generateId();
 
     this.send({

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -53,8 +53,8 @@ export class Extension {
   /**
    * Request to Station Extension for connecting a wallet
    *
-   * @returns {string}     name    'onConnect'
-   * @returns {AccAddress} payload Terra account address
+   * @returns {string}     name      'onConnect'
+   * @returns {AccAddress} payload   Terra account address
    */
   connect(): number {
     const id = this.generateId();
@@ -77,9 +77,9 @@ export class Extension {
    * @return {string}  payload.origin     origin address
    * @return {Msg[]}   payload.msgs       requested msgs
    * @return {boolean} payload.success
-   * @return {string}  payload.public_key Hex encoded public key
-   * @return {string}  payload.signature  Base64 encoded signature
-   * @return {number}  payload.recid      Recovery id
+   * @return {string}  payload.result.public_key Hex encoded public key
+   * @return {string}  payload.result.signature  Base64 encoded signature
+   * @return {number}  payload.result.recid      Recovery id
    */
   sign(msgs: Msg[]): number {
     const id = this.generateId();
@@ -102,11 +102,13 @@ export class Extension {
    * @return {number}  payload.id             identifier
    * @return {string}  payload.origin         origin address
    * @return {Msg[]}   payload.msgs           requested msgs
-   * @return {LCDClientConfig} payload.lcdClientConfig requested lcdClientConfig
+   * @return {LCDClientConfig} payload.lcdClientConfig
+   *                                          requested lcdClientConfig
    * @return {boolean} payload.success
-   * @return {number}  payload.result.code    Error code. null or undefined with successful tx
-   * @return {string}  payload.result.raw_log Raw log
-   * @return {string}  payload.result.txhash  Transaction hash
+   * @return {number|undefined} payload.result.code
+   *                                          error code. undefined with successful tx
+   * @return {string}  payload.result.raw_log raw log
+   * @return {string}  payload.result.txhash  transaction hash
    */
   post(msgs: Msg[], lcdClientConfig?: LCDClientConfig): number {
     const id = this.generateId();

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -73,6 +73,9 @@ export class Extension {
    * @param msgs transaction messages to be signed
    * @return {string}  name               'onSign'
    * @return {object}  payload
+   * @return {number}  payload.id         identifier
+   * @return {string}  payload.origin     origin address
+   * @return {Msg[]}   payload.msgs       requested msgs
    * @return {boolean} payload.success
    * @return {string}  payload.public_key Hex encoded public key
    * @return {string}  payload.signature  Base64 encoded signature
@@ -96,6 +99,10 @@ export class Extension {
    * @param msgs transaction messages to be signed
    * @return {string}  name                   'onPost'
    * @return {object}  payload
+   * @return {number}  payload.id             identifier
+   * @return {string}  payload.origin         origin address
+   * @return {Msg[]}   payload.msgs           requested msgs
+   * @return {LCDClientConfig} payload.lcdClientConfig requested lcdClientConfig
    * @return {boolean} payload.success
    * @return {number}  payload.result.code    Error code. null or undefined with successful tx
    * @return {string}  payload.result.raw_log Raw log

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -71,10 +71,12 @@ export class Extension {
    * Request to Station Extension for signing tx
    *
    * @param msgs transaction messages to be signed
-   * @return {string} name               'onSign'
-   * @return {string} payload.public_key Hex encoded public key
-   * @return {string} payload.signature  Base64 encoded signature
-   * @return {number} payload.recid      Recovery id
+   * @return {string}  name               'onSign'
+   * @return {object}  payload
+   * @return {boolean} payload.success
+   * @return {string}  payload.public_key Hex encoded public key
+   * @return {string}  payload.signature  Base64 encoded signature
+   * @return {number}  payload.recid      Recovery id
    */
   sign(msgs: Msg[]): number {
     const id = this.generateId();
@@ -92,10 +94,12 @@ export class Extension {
    * Request to Station Extension for sign and post to LCD server
    *
    * @param msgs transaction messages to be signed
-   * @return {string} name            'onPost'
-   * @return {number} payload.code    Error code. null or undefined with successful tx
-   * @return {string} payload.raw_log Raw log
-   * @return {string} payload.txhash  Transaction hash
+   * @return {string}  name                   'onPost'
+   * @return {object}  payload
+   * @return {boolean} payload.success
+   * @return {number}  payload.result.code    Error code. null or undefined with successful tx
+   * @return {string}  payload.result.raw_log Raw log
+   * @return {string}  payload.result.txhash  Transaction hash
    */
   post(msgs: Msg[], lcdClientConfig?: LCDClientConfig): number {
     const id = this.generateId();

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -8,6 +8,12 @@ interface ResponseData {
 
 type SendDataType = 'connect' | 'post' | 'sign';
 
+interface SignOptions {
+  lcdClientConfig: LCDClientConfig;
+  account_number?: number;
+  sequence?: number;
+}
+
 interface SendData {
   id: number | string;
   type: SendDataType;
@@ -100,15 +106,14 @@ export class Extension {
    * const stdSignMsg = StdSignMsg.fromData(payload.result.stdSignMsgData);
    * terra.tx.broadcast(new StdTx(stdSignMsg.msgs, stdSignMsg.fee, [sig], stdSignMsg.memo));
    */
-  sign(msgs: Msg[], account_number?: number, sequence?: number): number {
+  sign(msgs: Msg[], options: SignOptions): number {
     const id = this.generateId();
 
     this.send({
+      ...options,
       id,
       type: 'sign',
       msgs: msgs.map(msg => msg.toJSON()),
-      account_number,
-      sequence,
     });
 
     return id;

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -83,9 +83,11 @@ export class Extension {
    * @return {string}  payload.result.public_key Base64 encoded public key
    * @return {string}  payload.result.signature  Base64 encoded signature
    * @return {number}  payload.result.recid      Recovery id
-   * @return {StdSignMsg} payload.result.stdSignMsg
+   * @return {StdSignMsg.Data} payload.result.stdSignMsgData
    *
    * @example of broadcasting
+   *
+   * const { signature, public_key, recid, stdSignMsg } = payload.result;
    *
    * const sig = StdSignature.fromData({
    *   signature,
@@ -95,6 +97,7 @@ export class Extension {
    *  },
    * });
    *
+   * const stdSignMsg = StdSignMsg.fromData(payload.result.stdSignMsgData);
    * terra.tx.broadcast(new StdTx(stdSignMsg.msgs, stdSignMsg.fee, [sig], stdSignMsg.memo));
    */
   sign(msgs: Msg[], account_number?: number, sequence?: number): number {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -83,6 +83,19 @@ export class Extension {
    * @return {string}  payload.result.public_key Base64 encoded public key
    * @return {string}  payload.result.signature  Base64 encoded signature
    * @return {number}  payload.result.recid      Recovery id
+   * @return {StdSignMsg} payload.result.stdSignMsg
+   *
+   * @example of broadcasting
+   *
+   * const sig = StdSignature.fromData({
+   *   signature,
+   *   pub_key: {
+   *    type: 'tendermint/PubKeySecp256k1',
+   *    value: public_key,
+   *  },
+   * });
+   *
+   * terra.tx.broadcast(new StdTx(stdSignMsg.msgs, stdSignMsg.fee, [sig], stdSignMsg.memo));
    */
   sign(msgs: Msg[], account_number?: number, sequence?: number): number {
     const id = this.generateId();

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -71,6 +71,9 @@ export class Extension {
    * Request to Station Extension for signing tx
    *
    * @param msgs transaction messages to be signed
+   * @param account_number account number (optional)
+   * @param sequence sequence (optional)
+   *
    * @return {string}  name               'onSign'
    * @return {object}  payload
    * @return {number}  payload.id         identifier
@@ -81,13 +84,15 @@ export class Extension {
    * @return {string}  payload.result.signature  Base64 encoded signature
    * @return {number}  payload.result.recid      Recovery id
    */
-  sign(msgs: Msg[]): number {
+  sign(msgs: Msg[], account_number?: number, sequence?: number): number {
     const id = this.generateId();
 
     this.send({
       id,
       type: 'sign',
       msgs: msgs.map(msg => msg.toJSON()),
+      account_number,
+      sequence,
     });
 
     return id;
@@ -97,6 +102,8 @@ export class Extension {
    * Request to Station Extension for sign and post to LCD server
    *
    * @param msgs transaction messages to be signed
+   * @param lcdClientConfig LCDClientConfig (optional)
+   *
    * @return {string}  name                   'onPost'
    * @return {object}  payload
    * @return {number}  payload.id             identifier

--- a/src/key/Key.ts
+++ b/src/key/Key.ts
@@ -2,7 +2,6 @@ import * as bech32 from 'bech32';
 import * as HEX from 'crypto-js/enc-hex';
 import RIPEMD160 from 'crypto-js/ripemd160';
 import SHA256 from 'crypto-js/sha256';
-import * as secp256k1 from 'secp256k1';
 import { StdSignature } from '../core';
 import { StdTx } from '../core';
 import { StdSignMsg } from '../core';

--- a/src/key/Key.ts
+++ b/src/key/Key.ts
@@ -45,14 +45,12 @@ function pubKeyFromPublicKey(publicKey: Buffer): Buffer {
  */
 export abstract class Key {
   /**
-   * You will need to supply `ecdsaSign`, which produces a signature for an arbitrary bytes payload
+   * You will need to supply `sign`, which produces a signature for an arbitrary bytes payload
    * with the ECDSA curve secp256pk1.
    *
    * @param payload the data to be signed
    */
-  public abstract ecdsaSign(
-    payload: Buffer
-  ): { signature: Uint8Array; recid: number };
+  public abstract sign(payload: Buffer): Promise<Buffer>;
 
   /**
    * Terra account address. `terra-` prefixed.
@@ -87,16 +85,6 @@ export abstract class Key {
     this.valAddress = bech32.encode('terravaloper', Array.from(rawAddress));
     this.accPubKey = bech32.encode('terrapub', Array.from(rawPubKey));
     this.valPubKey = bech32.encode('terravaloperpub', Array.from(rawPubKey));
-  }
-
-  /**
-   * Signs a data to get signature buffer using ecdsaSign method
-   *
-   * @param payload the data to be signed
-   */
-  public async sign(payload: Buffer): Promise<Buffer> {
-    const { signature } = await this.ecdsaSign(payload);
-    return Buffer.from(signature);
   }
 
   /**

--- a/src/key/Key.ts
+++ b/src/key/Key.ts
@@ -45,14 +45,13 @@ function pubKeyFromPublicKey(publicKey: Buffer): Buffer {
  */
 export abstract class Key {
   /**
-   * You will need to supply `sign`, which produces a signature for an arbitrary bytes payload
+   * You will need to supply `ecdsaSign`, which produces a signature for an arbitrary bytes payload
    * with the ECDSA curve secp256pk1.
    *
    * @param payload the data to be signed
    */
   public abstract ecdsaSign(
-    payload: Buffer,
-    options?: secp256k1.SignOptions
+    payload: Buffer
   ): { signature: Uint8Array; recid: number };
 
   /**

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -110,4 +110,9 @@ export class MnemonicKey extends Key {
       Uint8Array.from(this.privateKey)
     );
   }
+
+  public async sign(payload: Buffer): Promise<Buffer> {
+    const { signature } = this.ecdsaSign(payload);
+    return Buffer.from(signature);
+  }
 }

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -103,15 +103,11 @@ export class MnemonicKey extends Key {
     this.mnemonic = mnemonic;
   }
 
-  public ecdsaSign(
-    payload: Buffer,
-    options?: secp256k1.SignOptions
-  ): { signature: Uint8Array; recid: number } {
+  public ecdsaSign(payload: Buffer): { signature: Uint8Array; recid: number } {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
     return secp256k1.ecdsaSign(
       Uint8Array.from(hash),
-      Uint8Array.from(this.privateKey),
-      options
+      Uint8Array.from(this.privateKey)
     );
   }
 }

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -103,12 +103,15 @@ export class MnemonicKey extends Key {
     this.mnemonic = mnemonic;
   }
 
-  public async sign(payload: Buffer): Promise<Buffer> {
+  public ecdsaSign(
+    payload: Buffer,
+    options?: secp256k1.SignOptions
+  ): { signature: Uint8Array; recid: number } {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
-    const { signature } = secp256k1.ecdsaSign(
+    return secp256k1.ecdsaSign(
       Uint8Array.from(hash),
-      Uint8Array.from(this.privateKey)
+      Uint8Array.from(this.privateKey),
+      options
     );
-    return Buffer.from(signature);
   }
 }

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -20,12 +20,15 @@ export class RawKey extends Key {
     this.privateKey = privateKey;
   }
 
-  public async sign(payload: Buffer): Promise<Buffer> {
+  public ecdsaSign(
+    payload: Buffer,
+    options?: secp256k1.SignOptions
+  ): { signature: Uint8Array; recid: number } {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
-    const { signature } = secp256k1.ecdsaSign(
+    return secp256k1.ecdsaSign(
       Uint8Array.from(hash),
-      Uint8Array.from(this.privateKey)
+      Uint8Array.from(this.privateKey),
+      options
     );
-    return Buffer.from(signature);
   }
 }

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -20,15 +20,11 @@ export class RawKey extends Key {
     this.privateKey = privateKey;
   }
 
-  public ecdsaSign(
-    payload: Buffer,
-    options?: secp256k1.SignOptions
-  ): { signature: Uint8Array; recid: number } {
+  public ecdsaSign(payload: Buffer): { signature: Uint8Array; recid: number } {
     const hash = Buffer.from(SHA256(payload.toString()).toString(), 'hex');
     return secp256k1.ecdsaSign(
       Uint8Array.from(hash),
-      Uint8Array.from(this.privateKey),
-      options
+      Uint8Array.from(this.privateKey)
     );
   }
 }

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -27,4 +27,9 @@ export class RawKey extends Key {
       Uint8Array.from(this.privateKey)
     );
   }
+
+  public async sign(payload: Buffer): Promise<Buffer> {
+    const { signature } = this.ecdsaSign(payload);
+    return Buffer.from(signature);
+  }
 }


### PR DESCRIPTION
## Description
This PR adds feature to get recovery id produced from secp256k1.ecdsaSign function. To verify signature in EVM, recovery id and public key should be accessible.

## Changes
* Add ecdsaSign method to MnemonicKey and RawKey which will passed to secp256k1.ecdsaSign to get signature and recid

## Definition of ecdsaSign method in MnemonicKey and RawKey
```typescript
  public ecdsaSign(
    payload: Buffer
  ): { signature: Uint8Array; recid: number };
```
