### PR TITLE
Feature: Add Event Parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.19",
+  "version": "0.4.20",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -84,6 +84,31 @@ export namespace SyncTxBroadcastResult {
   >;
 }
 
+export interface TxSearchResult {
+  total_count: number;
+  count: number;
+  page_number: number;
+  page_total: number;
+  limit: number;
+  txs: TxInfo[];
+}
+
+export namespace TxSearchResult {
+  export interface Data {
+    total_count: string;
+    count: string;
+    page_number: string;
+    page_total: string;
+    limit: string;
+    txs: TxInfo.Data[];
+  }
+}
+
+export interface TxSearchOptions {
+  page: number;
+  limit: number;
+}
+
 export class TxAPI extends BaseAPI {
   constructor(public lcd: LCDClient) {
     super(lcd.apiRequester);
@@ -292,6 +317,23 @@ export class TxAPI extends BaseAPI {
     ).then(d => ({
       height: Number.parseInt(d.height),
       txhash: d.txhash,
+    }));
+  }
+
+  /**
+   * Search for transactions based on event attributes.
+   * @param options
+   */
+  public async search(
+    options: Partial<TxSearchOptions> | {}
+  ): Promise<TxSearchResult> {
+    return this.c.getRaw<TxSearchResult.Data>(`/txs`, options).then(d => ({
+      total_count: Number.parseInt(d.total_count),
+      count: Number.parseInt(d.count),
+      page_number: Number.parseInt(d.page_number),
+      page_total: Number.parseInt(d.page_total),
+      limit: Number.parseInt(d.limit),
+      txs: d.txs.map(txdata => TxInfo.fromData(txdata)),
     }));
   }
 }

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../core';
 import { hashAmino } from '../../../util/hash';
 import { LCDClient } from '../LCDClient';
-import { Event, Events, TxLog } from '../../../core';
+import { Event, EventsByType, TxLog } from '../../../core';
 
 interface EstimateFeeResponse {
   gas: string;
@@ -38,7 +38,7 @@ export interface BlockTxBroadcastResult {
   logs: TxLog[];
   gas_wanted: number;
   gas_used: number;
-  events: Events;
+  events: EventsByType;
   code?: number;
 }
 
@@ -283,7 +283,7 @@ export class TxAPI extends BaseAPI {
         raw_log: d.raw_log,
         gas_wanted: Number.parseInt(d.gas_wanted),
         gas_used: Number.parseInt(d.gas_used),
-        events: Events.parse(d.events),
+        events: EventsByType.parse(d.events),
         code: d.code,
       };
     });

--- a/src/client/lcd/api/WasmAPI.ts
+++ b/src/client/lcd/api/WasmAPI.ts
@@ -28,7 +28,6 @@ export interface WasmParams {
   max_contract_size: number;
   max_contract_gas: number;
   max_contract_msg_size: number;
-  gas_multiplier: number;
 }
 
 export namespace WasmParams {
@@ -36,7 +35,6 @@ export namespace WasmParams {
     max_contract_size: string;
     max_contract_gas: string;
     max_contract_msg_size: string;
-    gas_multiplier: string;
   }
 }
 
@@ -77,7 +75,6 @@ export class WasmAPI extends BaseAPI {
         max_contract_size: Number.parseInt(d.max_contract_size),
         max_contract_gas: Number.parseInt(d.max_contract_gas),
         max_contract_msg_size: Number.parseInt(d.max_contract_msg_size),
-        gas_multiplier: Number.parseInt(d.gas_multiplier),
       }));
   }
 }

--- a/src/core/TxInfo.spec.ts
+++ b/src/core/TxInfo.spec.ts
@@ -1,10 +1,118 @@
 import { TxInfo } from './TxInfo';
 const data = require('./TxInfo.data.json');
 
+const instantiateContractTxData = {
+  height: '301435',
+  txhash: '69CA62F1328A3FBC810A3E370A186BC2A5FAED2739848CA3336580DD17C58F7E',
+  raw_log:
+    '[{"msg_index":0,"log":"","events":[{"type":"instantiate_contract","attributes":[{"key":"owner","value":"terra1t72mplryz3n2y953w44fc3rj0yp4m82qvkhrz3"},{"key":"code_id","value":"118"},{"key":"contract_address","value":"terra1emf0rwa3nfljdn6mq0mycy8vxcdaklgmzwam2s"}]},{"type":"message","attributes":[{"key":"action","value":"instantiate_contract"},{"key":"module","value":"wasm"}]}]}]',
+  logs: [
+    {
+      msg_index: 0,
+      log: '',
+      events: [
+        {
+          type: 'instantiate_contract',
+          attributes: [
+            {
+              key: 'owner',
+              value: 'terra1t72mplryz3n2y953w44fc3rj0yp4m82qvkhrz3',
+            },
+            {
+              key: 'code_id',
+              value: '118',
+            },
+            {
+              key: 'contract_address',
+              value: 'terra1emf0rwa3nfljdn6mq0mycy8vxcdaklgmzwam2s',
+            },
+          ],
+        },
+        {
+          type: 'message',
+          attributes: [
+            {
+              key: 'action',
+              value: 'instantiate_contract',
+            },
+            {
+              key: 'module',
+              value: 'wasm',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  gas_wanted: '136830',
+  gas_used: '113019',
+  tx: {
+    type: 'core/StdTx',
+    value: {
+      msg: [
+        {
+          type: 'wasm/MsgInstantiateContract',
+          value: {
+            owner: 'terra1t72mplryz3n2y953w44fc3rj0yp4m82qvkhrz3',
+            code_id: '118',
+            init_msg:
+              'eyJmZWUiOnsiZGVub20iOiJ1bHVuYSIsImFtb3VudCI6IjEwMCJ9fQ==',
+            init_coins: [],
+            migratable: false,
+          },
+        },
+      ],
+      fee: {
+        amount: [
+          {
+            denom: 'uluna',
+            amount: '20525',
+          },
+        ],
+        gas: '136830',
+      },
+      signatures: [
+        {
+          pub_key: {
+            type: 'tendermint/PubKeySecp256k1',
+            value: 'A5NuEwpsm7e/WbVT46IUx1MHhgAr4sBVjNymm8jfldoi',
+          },
+          signature:
+            '7vqw1gAhQ9O9pXVXKIVwtw0O6wPnvWnLT2ATrUkXIDlUN2VJVdzKF5QpDdsvJIWQlz15JhfeHyFlyINiudP3Bg==',
+        },
+      ],
+      memo: '',
+    },
+  },
+  timestamp: '2020-09-23T13:17:22Z',
+};
+
 describe('TxInfo', () => {
   it('deserializes', () => {
     data.txs.forEach((txInfo: TxInfo.Data) => {
       expect(txInfo).toMatchObject(TxInfo.fromData(txInfo).toData());
+    });
+  });
+
+  it('parses events correctly', () => {
+    const tx = TxInfo.fromData(instantiateContractTxData as TxInfo.Data);
+    const {
+      message: { action, module },
+      instantiate_contract: { owner, code_id, contract_address },
+    } = tx.logs![0].events;
+
+    expect({
+      action: action[0],
+      module: module[0],
+      owner: owner[0],
+      code_id: code_id[0],
+      contract_address: contract_address[0],
+    }).toMatchObject({
+      action: 'instantiate_contract',
+      module: 'wasm',
+      owner: 'terra1t72mplryz3n2y953w44fc3rj0yp4m82qvkhrz3',
+      code_id: '118',
+      contract_address: 'terra1emf0rwa3nfljdn6mq0mycy8vxcdaklgmzwam2s',
     });
   });
 });

--- a/src/core/TxInfo.ts
+++ b/src/core/TxInfo.ts
@@ -79,17 +79,17 @@ export interface Event {
   attributes: EventKV[];
 }
 
-export interface Events {
+export interface EventsByType {
   [type: string]: {
     [key: string]: string[];
   };
 }
 
-export namespace Events {
+export namespace EventsByType {
   export type Data = Event[];
 
-  export function parse(eventData: Event[]): Events {
-    const events: Events = {};
+  export function parse(eventData: Event[]): EventsByType {
+    const events: EventsByType = {};
     eventData.forEach(ev => {
       ev.attributes.forEach(attr => {
         if (!(ev.type in events)) {
@@ -108,7 +108,7 @@ export namespace Events {
 }
 
 export class TxLog extends JSONSerializable<TxLog.Data> {
-  public events: Events;
+  public events: EventsByType;
 
   constructor(
     public msg_index: number,
@@ -116,7 +116,7 @@ export class TxLog extends JSONSerializable<TxLog.Data> {
     private _eventData: Event[]
   ) {
     super();
-    this.events = Events.parse(_eventData);
+    this.events = EventsByType.parse(_eventData);
   }
 
   public static fromData(data: TxLog.Data): TxLog {

--- a/src/core/params/proposals/ParameterChangeProposal.spec.ts
+++ b/src/core/params/proposals/ParameterChangeProposal.spec.ts
@@ -159,6 +159,46 @@ const jiguJSON = {
         key: 'InflationRateChange',
         value: '"0.010000000000000000"',
       },
+      {
+        subspace: 'mint',
+        key: 'BlocksPerYear',
+        value: '"1000000"',
+      },
+      {
+        subspace: 'mint',
+        key: 'MintDenom',
+        value: '"uluna"',
+      },
+      {
+        subspace: 'mint',
+        key: 'InflationMin',
+        value: '"0.010000000000000000"',
+      },
+      {
+        subspace: 'mint',
+        key: 'InflationMax',
+        value: '"0.010000000000000000"',
+      },
+      {
+        subspace: 'mint',
+        key: 'GoalBonded',
+        value: '"0.010000000000000000"',
+      },
+      {
+        subspace: 'wasm',
+        key: 'maxcontractgas',
+        value: '"1000000"',
+      },
+      {
+        subspace: 'wasm',
+        key: 'maxcontractmsgsize',
+        value: '"1000000"',
+      },
+      {
+        subspace: 'wasm',
+        key: 'maxcontractsize',
+        value: '"1000000"',
+      },
     ],
   },
 };
@@ -233,6 +273,16 @@ describe('ParamaterChangeProposal', () => {
       },
       mint: {
         InflationRateChange: new Dec(0.01),
+        BlocksPerYear: 1000000,
+        MintDenom: 'uluna',
+        InflationMin: new Dec(0.01),
+        InflationMax: new Dec(0.01),
+        GoalBonded: new Dec(0.01),
+      },
+      wasm: {
+        maxcontractgas: 1000000,
+        maxcontractmsgsize: 1000000,
+        maxcontractsize: 1000000,
       },
     });
 

--- a/src/core/wasm/params.ts
+++ b/src/core/wasm/params.ts
@@ -11,20 +11,16 @@ type MaxContractMsgSize = ParamChange.Type<
   number
 >;
 
-type GasMultiplier = ParamChange.Type<'wasm', 'gasmultiplier', number>;
-
 export type WasmParamChange =
   | MaxContractSize
   | MaxContractGas
-  | MaxContractMsgSize
-  | GasMultiplier;
+  | MaxContractMsgSize;
 
 export namespace WasmParamChange {
   export type Data =
     | ParamChange.Data.Type<MaxContractSize>
     | ParamChange.Data.Type<MaxContractGas>
-    | ParamChange.Data.Type<MaxContractMsgSize>
-    | ParamChange.Data.Type<GasMultiplier>;
+    | ParamChange.Data.Type<MaxContractMsgSize>;
 }
 
 export interface WasmParamChanges {
@@ -32,7 +28,6 @@ export interface WasmParamChanges {
     maxcontractsize?: number;
     maxcontractgas?: number;
     maxcontractmsgsize?: number;
-    gasmultiplier?: number;
   };
 }
 
@@ -42,7 +37,6 @@ export namespace WasmParamChanges {
       maxcontractsize: [Convert.toNumber, Convert.toFixed],
       maxcontractgas: [Convert.toNumber, Convert.toFixed],
       maxcontractmsgsize: [Convert.toNumber, Convert.toFixed],
-      gasmultiplier: [Convert.toNumber, Convert.toFixed],
     },
   };
 }


### PR DESCRIPTION
## Summary of changes

- **BREAKING**: Event Parsing in `TxLog` and `BlockBroadcastResult`
- Update `TxInfo` and `TxLog` interfaces to Columbus-4
- Add `TxAPI.search`

--

## Event Parsing

The main breaking change is modifying `TxInfo.events` type signature from `Event[]` to `Events`. `Events` holds a parsed version of the blockchain events in a nested object instead of an inconvenient array.

To illustrate:

Before:

```ts
...
const storeCodeTxResult = await terra.tx.broadcast(tx);
const codeId = +storeCodeTxResult.logs[0].events[1].attributes[1].value;
```

After:

```ts
const storeCodeTxResult = await terra.tx.broadcast(tx);
const {
  store_code: { code_id }
} = storeCodeTxResult.logs[0].events;
const codeId = +code_id[0];
```

You are no longer burdened with having to know which order the event comes in, and you can specify the event type and attribute to make your query. TxInfo / Broadcast will automatically parse the response for you.

## Update `TxInfo` and `TxLog` interfaces

As of Columbus-4, the following interfaces have changes.

### TxInfo

- `events: Event[]` is no longer available at the top level, and is now only available inside `TxInfo.logs`

```ts
export namespace TxInfo {
  export interface Data {
    height: string;
    txhash: string;
    raw_log: string;
    logs?: TxLog.Data[];
    gas_wanted: string;
    gas_used: string;
    tx: StdTx.Data;
    timestamp: string;
    code?: number;
  }
}
```

### TxLog

- `success: boolean` is no longer a reported field

```ts
export namespace TxLog {
  export interface Data {
    msg_index: number;
    log: string;
    events: Event[];
  }
}
```

## TX Search

You can now search for transactions. The below shows an example:

```ts
const searchResults = await terra.tx.search({
  limit: 20,
  page: 2,
  "message.action": "send"
});

console.log(searchResults.txs);
```