### PR TITLE
Fix: TxInfo.logs.events should be array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.4.19",
+  "version": "0.4.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,19 @@
 {
-  "version": "0.4.20",
+  "name": "@terra-money/terra.js",
+  "version": "0.4.21",
+  "description": "The JavaScript SDK for Terra",
   "license": "MIT",
+  "author": "Terraform Labs, PTE.",
+  "keywords": [
+    "terra",
+    "crypto",
+    "blockchain",
+    "smart-contracts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/terra-project/terra.js.git"
+  },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "browser": "dist/bundle.js",
@@ -37,8 +50,6 @@
     "trailingComma": "es5",
     "arrowParens": "avoid"
   },
-  "name": "@terra-money/terra.js",
-  "author": "Terraform Labs, PTE.",
   "devDependencies": {
     "@types/bech32": "^1.1.2",
     "@types/crypto-js": "^3.1.47",

--- a/src/core/TxInfo.spec.ts
+++ b/src/core/TxInfo.spec.ts
@@ -99,7 +99,7 @@ describe('TxInfo', () => {
     const {
       message: { action, module },
       instantiate_contract: { owner, code_id, contract_address },
-    } = tx.logs![0].events;
+    } = tx.logs![0].eventsByType;
 
     expect({
       action: action[0],

--- a/src/core/TxInfo.ts
+++ b/src/core/TxInfo.ts
@@ -108,15 +108,15 @@ export namespace EventsByType {
 }
 
 export class TxLog extends JSONSerializable<TxLog.Data> {
-  public events: EventsByType;
+  public eventsByType: EventsByType;
 
   constructor(
     public msg_index: number,
     public log: string,
-    private _eventData: Event[]
+    private events: Event[]
   ) {
     super();
-    this.events = EventsByType.parse(_eventData);
+    this.eventsByType = EventsByType.parse(this.events);
   }
 
   public static fromData(data: TxLog.Data): TxLog {
@@ -125,11 +125,11 @@ export class TxLog extends JSONSerializable<TxLog.Data> {
   }
 
   public toData(): TxLog.Data {
-    const { msg_index, log } = this;
+    const { msg_index, log, events } = this;
     return {
       msg_index,
       log,
-      events: this._eventData,
+      events,
     };
   }
 }

--- a/src/core/TxInfo.ts
+++ b/src/core/TxInfo.ts
@@ -113,7 +113,7 @@ export class TxLog extends JSONSerializable<TxLog.Data> {
   constructor(
     public msg_index: number,
     public log: string,
-    private events: Event[]
+    public events: Event[]
   ) {
     super();
     this.eventsByType = EventsByType.parse(this.events);


### PR DESCRIPTION
## Description
In JSON tx results, `logs.events` is array of objects, and replacing variable `events` to object of arrays confuses developers.

## Changes
* expose events as an array which is previous behavior.
* expose eventsByType