### PR TITLE
Add typeguard for TxBroadcastResult

### DIFF
--- a/integration-tests/contract.ts
+++ b/integration-tests/contract.ts
@@ -5,6 +5,7 @@ import {
   MsgExecuteContract,
   MnemonicKey,
   StdFee,
+  isTxError,
 } from '../src';
 import * as fs from 'fs';
 
@@ -28,12 +29,14 @@ async function main(): Promise<void> {
     fs.readFileSync('contract.wasm').toString('base64')
   );
   const storeCodeTx = await wallet.createAndSignTx({
-    msgs: [storeCode]
+    msgs: [storeCode],
   });
   const storeCodeTxResult = await terra.tx.broadcast(storeCodeTx);
 
-  if (!storeCodeTxResult.logs) {
-    throw new Error(`store code failed. code: ${storeCodeTxResult.code}, codespace: ${storeCodeTxResult.codespace}, raw_log: ${storeCodeTxResult.raw_log}`);
+  if (isTxError(storeCodeTxResult)) {
+    throw new Error(
+      `store code failed. code: ${storeCodeTxResult.code}, codespace: ${storeCodeTxResult.codespace}, raw_log: ${storeCodeTxResult.raw_log}`
+    );
   }
 
   const {
@@ -49,12 +52,13 @@ async function main(): Promise<void> {
     { uluna: 10000000, ukrw: 1000000 }, // init coins
     false // migratable
   );
-  const instantiateTx = await wallet.createAndSignTx({
-    msgs: [instantiate]
-  });
-  const instantiateTxResult = await terra.tx.broadcast(instantiateTx);
 
-  if (!instantiateTxResult.logs) {
+  const instantiateTx = await wallet.createAndSignTx({
+    msgs: [instantiate],
+  });
+  const instantiateTxResult = await terra.tx.broadcastSync(instantiateTx);
+
+  if (isTxError(instantiateTxResult)) {
     throw new Error(
       `instantiate failed. code: ${instantiateTxResult.code}, codespace: ${instantiateTxResult.codespace}, raw_log: ${instantiateTxResult.raw_log}`
     );
@@ -63,6 +67,7 @@ async function main(): Promise<void> {
   const {
     instantiate_contract: { contract_address },
   } = instantiateTxResult.logs[0].eventsByType;
+
   const execute = new MsgExecuteContract(
     wallet.key.accAddress, // sender
     contract_address[0], // contract account address
@@ -71,7 +76,6 @@ async function main(): Promise<void> {
   );
   const executeTx = await wallet.createAndSignTx({
     msgs: [execute],
-    fee: new StdFee(10000000, { uluna: 10000000 }),
   });
   const executeTxResult = await terra.tx.broadcast(executeTx);
   console.log(executeTxResult);

--- a/integration-tests/contract.ts
+++ b/integration-tests/contract.ts
@@ -33,6 +33,8 @@ async function main(): Promise<void> {
   });
   const storeCodeTxResult = await terra.tx.broadcast(storeCodeTx);
 
+  console.log(storeCodeTxResult);
+
   if (isTxError(storeCodeTxResult)) {
     throw new Error(
       `store code failed. code: ${storeCodeTxResult.code}, codespace: ${storeCodeTxResult.codespace}, raw_log: ${storeCodeTxResult.raw_log}`
@@ -56,7 +58,9 @@ async function main(): Promise<void> {
   const instantiateTx = await wallet.createAndSignTx({
     msgs: [instantiate],
   });
-  const instantiateTxResult = await terra.tx.broadcastSync(instantiateTx);
+  const instantiateTxResult = await terra.tx.broadcast(instantiateTx);
+
+  console.log(instantiateTxResult);
 
   if (isTxError(instantiateTxResult)) {
     throw new Error(
@@ -76,6 +80,7 @@ async function main(): Promise<void> {
   );
   const executeTx = await wallet.createAndSignTx({
     msgs: [execute],
+    fee: new StdFee(100, { uluna: 1 }),
   });
   const executeTxResult = await terra.tx.broadcast(executeTx);
   console.log(executeTxResult);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -66,8 +66,8 @@ export interface TxError {
 
 export function isTxError<
   T extends TxBroadcastResult<B, C>,
-  B extends Block | Sync,
-  C extends TxSuccess | TxError
+  B extends Block | Sync | Sync,
+  C extends TxSuccess | TxError | {}
 >(x: T): x is T & TxBroadcastResult<B, TxError> {
   return (x as T & TxError).code !== undefined;
 }
@@ -102,7 +102,7 @@ export namespace AsyncTxBroadcastResult {
 export namespace SyncTxBroadcastResult {
   export type Data = Pick<
     BlockTxBroadcastResult.Data,
-    'height' | 'txhash' | 'raw_log' | 'logs' | 'code' | 'codespace'
+    'height' | 'txhash' | 'raw_log' | 'code' | 'codespace'
   >;
 }
 
@@ -333,7 +333,7 @@ export class TxAPI extends BaseAPI {
    */
   public async broadcastSync(
     tx: StdTx
-  ): Promise<TxBroadcastResult<Sync, TxSuccess | TxError>> {
+  ): Promise<TxBroadcastResult<Sync, {} | TxError>> {
     return this._broadcast<SyncTxBroadcastResult.Data>(tx, Broadcast.SYNC).then(
       d => {
         const blockResult: any = {
@@ -341,10 +341,6 @@ export class TxAPI extends BaseAPI {
           txhash: d.txhash,
           raw_log: d.raw_log,
         };
-
-        if (d.logs) {
-          blockResult.logs = d.logs.map(l => TxLog.fromData(l));
-        }
 
         if (d.code) {
           blockResult.code = d.code;

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -66,7 +66,7 @@ export interface TxError {
 
 export function isTxError<
   T extends TxBroadcastResult<B, C>,
-  B extends Block | Sync | Sync,
+  B extends Block | Sync,
   C extends TxSuccess | TxError | {}
 >(x: T): x is T & TxBroadcastResult<B, TxError> {
   return (x as T & TxError).code !== undefined;


### PR DESCRIPTION
If you are using typescript, you can import `isTxError()` function as a typeguard, which enforces good practice of checking that the returned result did not encounter an error.

Example from `contract.ts` integration test:

```ts
 const storeCode = new MsgStoreCode(
    wallet.key.accAddress,
    fs.readFileSync('contract.wasm').toString('base64')
  );
  const storeCodeTx = await wallet.createAndSignTx({
    msgs: [storeCode],
  });
  const storeCodeTxResult = await terra.tx.broadcast(storeCodeTx);

  console.log(storeCodeTxResult);

  if (isTxError(storeCodeTxResult)) {
    throw new Error(
      `store code failed. code: ${storeCodeTxResult.code}, codespace: ${storeCodeTxResult.codespace}, raw_log: ${storeCodeTxResult.raw_log}`
    );
  }

  const {
    store_code: { code_id },
  } = storeCodeTxResult.logs[0].eventsByType;
```

Without the type guard, TypeScript will complain.

![image](https://user-images.githubusercontent.com/990030/94594552-8ac5da80-02c4-11eb-97a3-9c215cc3f804.png)

With the type guard, you can access the logs:

![image](https://user-images.githubusercontent.com/990030/94594637-ab8e3000-02c4-11eb-8faf-217fd30a769f.png)

TypeScript will also be aware when the message contains `code`, `codespace` when it has an error.

![image](https://user-images.githubusercontent.com/990030/94594685-ba74e280-02c4-11eb-8ec6-39a2de7c2f9a.png)
