### PR TITLE
Make wasm msg arguments optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.5",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/wasm/msgs/MsgExecuteContract.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.ts
@@ -17,7 +17,7 @@ export class MsgExecuteContract extends JSONSerializable<
     public sender: AccAddress,
     public contract: AccAddress,
     public execute_msg: object,
-    coins: Coins.Input
+    coins: Coins.Input = {}
   ) {
     super();
     this.coins = new Coins(coins);

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -18,8 +18,8 @@ export class MsgInstantiateContract extends JSONSerializable<
     public owner: AccAddress,
     public code_id: number,
     public init_msg: object,
-    init_coins: Coins.Input,
-    public migratable: boolean
+    init_coins: Coins.Input = {},
+    public migratable: boolean = false
   ) {
     super();
     this.init_coins = new Coins(init_coins);


### PR DESCRIPTION
Changes `MsgInstantiateContract` and `MsgExecuteContract` arguments for `coins` and `migratable` optional.