### PR TITLE
feat(client): added reconnect feature to WebSocketClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.10",
+  "version": "0.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,6 +2239,21 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "bufferutil": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+        }
+      }
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -9684,6 +9699,21 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf-8-validate": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+        }
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,12 @@
     "bech32": "^1.1.4",
     "bip32": "^2.0.6",
     "bip39": "^3.0.2",
+    "bufferutil": "^4.0.1",
     "crypto-js": "3.3.0",
     "decimal.js": "^10.2.1",
     "post-message-stream": "^3.0.0",
     "secp256k1": "^4.0.2",
+    "utf-8-validate": "^5.0.2",
     "ws": "^7.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -91,10 +91,10 @@ function makeQueryParams(query: TendermintQuery): string {
  * This allows for subscribing to Tendermint events through WebSocket.
  *
  * ### Events
- * **error** fires when error raises
- * **connect** fires after connection establishment
- * **reconnect** fires upon every attempt of reconnection
- * **destroyed** fires when socket has been destroyed
+ * **error** emitted when error raises
+ * **connect** emitted after connection establishment
+ * **reconnect** emitted upon every attempt of reconnection
+ * **destroyed** emitted when socket has been destroyed
  *
  * ### Example
  *

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -2,25 +2,6 @@ import { EventEmitter } from 'events';
 import WebSocket from 'ws';
 import { hashAmino } from '../util/hash';
 
-export interface WebSocketClientConfig {
-  /**
-   * The WebSocket endpoint URL on the Tendermint RPC server.
-   * Ex: ws://localhost:26657/websocket
-   */
-  URL: string;
-  /**
-   * Set 0 for not to attemp reconnect
-   * Set -1 to attempt infinite times
-   * Set > 0 to attempt specified times
-   */
-  reconnectCount: number;
-
-  /**
-   * reconnect interval in millisecond
-   */
-  reconnectInterval: number;
-}
-
 type Callback = (data: TendermintSubscriptionResponse) => void;
 
 export interface TendermintSubscriptionResponse {
@@ -153,6 +134,13 @@ export class WebSocketClient extends EventEmitter {
   private socket!: WebSocket;
   private _reconnectCount: number;
 
+  /**
+   * WebSocketClient constructor
+   * @param URL The WebSocket endpoint URL on the Tendermint RPC server.
+   *            Ex: ws://localhost:26657/websocket
+   * @param reconnectCount 0 for not to attempt reconnect, -1 for infinite, > 0 for number of times to attempt
+   * @param reconnectInterval retry interval in milliseconds
+   */
   constructor(
     private URL: string,
     private reconnectCount = 0,
@@ -164,6 +152,9 @@ export class WebSocketClient extends EventEmitter {
     this.shouldAttemptReconnect = !!this.reconnectInterval;
   }
 
+  /**
+   * Destroys class as well as socket
+   */
   destroy() {
     this.shouldAttemptReconnect = false;
     this.reconnectTimeoutId && clearTimeout(this.reconnectTimeoutId);


### PR DESCRIPTION
## Description
This PR adds feature that allows WebSocketClient to be reconnected after the disconnect.

## Changes
* added destroy method to WebSocketClient
* removed socket parameter from callback
* changed constructor signature
* WebSocketClient extends EventEmitter
**error** emitted when error raises
**connect** emitted after connection establishment
**reconnect** emitted upon every attempt of reconnection
**destroyed** emitted when socket has been destroyed
