### PR TITLE
Fix CLIKey and Extension.isAvailable

### DIFF
--- a/integration-tests/clikey.ts
+++ b/integration-tests/clikey.ts
@@ -1,6 +1,6 @@
 import { StdFee, MsgSend } from '../src';
 import { LocalTerra } from '../src';
-import { CLIKey } from '../src';
+import { CLIKey } from '../src/key/CLIKey';
 
 const terra = new LocalTerra();
 const { test1 } = terra.wallets;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.13",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git://github.com/terra-project/terra.js.git"
   },
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
     "type": "git",
     "url": "git://github.com/terra-project/terra.js.git"
   },
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "typings": "dist/index.d.ts",
-  "browser": "dist/bundle.js",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "0.5.13",
+  "version": "1.0.0-rc.0",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",
@@ -21,7 +21,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "tsc --module commonjs && webpack --mode production",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -22,9 +22,7 @@ interface Option extends CreateTxOptions {
 declare global {
   interface Window {
     // add you custom properties and methods
-    Terra: {
-      isAvailable: boolean;
-    };
+    isTerraExtensionAvailable: boolean;
   }
 }
 
@@ -61,7 +59,7 @@ export class Extension {
    * Indicates the Station Extension is installed and availble (requires extension v1.1 or later)
    */
   get isAvailable(): boolean {
-    return window?.Terra?.isAvailable;
+    return !!window.isTerraExtensionAvailable;
   }
 
   /**

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,4 +1,13 @@
 export * from './Key';
 export * from './MnemonicKey';
 export * from './RawKey';
-export * from './CLIKey';
+
+let CLIKey: any;
+
+declare const __WEBPACK_BROWSER__: boolean | undefined;
+
+if (typeof __WEBPACK_BROWSER__ !== 'boolean') {
+  ({ CLIKey } = require('./CLIKey'));
+}
+
+export { CLIKey };

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,13 +1,3 @@
 export * from './Key';
 export * from './MnemonicKey';
 export * from './RawKey';
-
-let CLIKey: any;
-
-declare const __WEBPACK_BROWSER__: boolean | undefined;
-
-if (typeof __WEBPACK_BROWSER__ !== 'boolean') {
-  ({ CLIKey } = require('./CLIKey'));
-}
-
-export { CLIKey };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin;
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const commonConfig = {
   entry: './src/index.ts',
@@ -13,7 +12,7 @@ const commonConfig = {
         test: /\.tsx?$/,
         use: 'ts-loader',
         exclude: /node_modules/,
-      }
+      },
     ],
   },
   resolve: {
@@ -21,8 +20,10 @@ const commonConfig = {
     plugins: [new TsconfigPathsPlugin()],
   },
   plugins: [
-    new webpack.IgnorePlugin(/wordlists\/(french|spanish|italian|korean|chinese_simplified|chinese_traditional|japanese)\.json$/)
-  ]
+    new webpack.IgnorePlugin(
+      /wordlists\/(french|spanish|italian|korean|chinese_simplified|chinese_traditional|japanese)\.json$/
+    ),
+  ],
 };
 
 const webConfig = {
@@ -36,7 +37,9 @@ const webConfig = {
   },
   plugins: [
     ...commonConfig.plugins,
-    new webpack.IgnorePlugin(/^\.\/CLIKey/)
+    new webpack.DefinePlugin({
+      __WEBPACK_BROWSER__: true,
+    }),
     // new BundleAnalyzerPlugin(),
   ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,9 +37,6 @@ const webConfig = {
   },
   plugins: [
     ...commonConfig.plugins,
-    new webpack.DefinePlugin({
-      __WEBPACK_BROWSER__: true,
-    }),
     // new BundleAnalyzerPlugin(),
   ],
 };


### PR DESCRIPTION
Version will be updated to 1.0.0 to follow https://semver.org/ standard.

## CLIKey
IgnorePlugin cannot ignore source code line for importing CLIKey which leads browser to raise an exception. To fix this problem, CLIKey was removed from `index`. Developer have to explicitly import CLIKey from now on.

## Extension
Extension.isAvailable was using `window.Terra.isAvailable` variable to determine whether there's Terra Station Extension installed or not, assigned by Terra Station Extension.
However, there will be a conflict on `window.Terra` when terra.js is included by using <script> tag