### PR TITLE
Fix: Oracle Null Check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/lcd/api/OracleAPI.ts
+++ b/src/client/lcd/api/OracleAPI.ts
@@ -122,9 +122,13 @@ export class OracleAPI extends BaseAPI {
    * Gets the Oracle module's currently registered exchange rate for LUNA in all available denominations.
    */
   public async exchangeRates(): Promise<Coins> {
-    return this.c
-      .get<Coins.Data>(`/oracle/denoms/exchange_rates`)
-      .then(d => Coins.fromData(d.result));
+    return this.c.get<Coins.Data>(`/oracle/denoms/exchange_rates`).then(d => {
+      if (d) {
+        return Coins.fromData(d.result);
+      } else {
+        return new Coins({});
+      }
+    });
   }
 
   /**

--- a/src/client/lcd/api/OracleAPI.ts
+++ b/src/client/lcd/api/OracleAPI.ts
@@ -123,7 +123,7 @@ export class OracleAPI extends BaseAPI {
    */
   public async exchangeRates(): Promise<Coins> {
     return this.c.get<Coins.Data>(`/oracle/denoms/exchange_rates`).then(d => {
-      if (d) {
+      if (d?.result) {
         return Coins.fromData(d.result);
       } else {
         return new Coins({});

--- a/src/core/Coins.ts
+++ b/src/core/Coins.ts
@@ -61,7 +61,7 @@ export class Coins
   /**
    * @param arg coins to input
    */
-  constructor(arg: Coins.Input) {
+  constructor(arg: Coins.Input = {}) {
     super();
     if (arg instanceof Coins) {
       this._coins = { ...arg._coins };
@@ -93,7 +93,9 @@ export class Coins
         !this.toArray().every(c => c.isDecCoin()) &&
         !this.toArray().every(c => c.isIntCoin())
       ) {
-        throw new Error('non-homogenous instantiation of Coins not supported');
+        throw new Error(
+          `non-homogenous instantiation of Coins not supported: ${this.toString()}`
+        );
       }
     }
   }


### PR DESCRIPTION
In `LCDClient`:

Sometimes, the result from `OracleAPI.exchangeRate(denom)` will complain because the result from `OracleAPI.exchangeRates()` is `undefined`. The intended behavior is `OracleAPI.exchangeRate(denom)` should be `undefined` when not found -- OracleAPI.exchangeRates() should be empty `Coins` object.
