### PR TITLE
Added support for height parameter in the taxRate LCD api

### DIFF
--- a/src/client/lcd/api/TreasuryAPI.ts
+++ b/src/client/lcd/api/TreasuryAPI.ts
@@ -63,7 +63,7 @@ export class TreasuryAPI extends BaseAPI {
   /**
    * Gets the current registered Tax Rate.
    */
-  public async taxRate(height?: number | undefined): Promise<Dec> {
+  public async taxRate(height?: number): Promise<Dec> {
     return this.c
       .get<string>(`/treasury/tax_rate`, height ? { height } : undefined)
       .then(d => new Dec(d.result));

--- a/src/client/lcd/api/TreasuryAPI.ts
+++ b/src/client/lcd/api/TreasuryAPI.ts
@@ -63,9 +63,9 @@ export class TreasuryAPI extends BaseAPI {
   /**
    * Gets the current registered Tax Rate.
    */
-  public async taxRate(): Promise<Dec> {
+  public async taxRate(height?: number | undefined): Promise<Dec> {
     return this.c
-      .get<string>(`/treasury/tax_rate`)
+      .get<string>(`/treasury/tax_rate`, height ? { height } : undefined)
       .then(d => new Dec(d.result));
   }
 


### PR DESCRIPTION
I noticed that the LCD api supports a providing height for the taxRate API node. 
This feature exists in the FCD implementation of the LCD client, so I ported it over to the LCD client in terra.js
https://github.com/terra-project/fcd/blob/develop/src/lib/lcd.ts