### PR TITLE
Allow optional parameters for lcd.staking.unbondingDelegations

### DIFF
--- a/src/client/lcd/api/StakingAPI.ts
+++ b/src/client/lcd/api/StakingAPI.ts
@@ -138,8 +138,8 @@ export class StakingAPI extends BaseAPI {
    * @param validator validator's operator address
    */
   public async unbondingDelegation(
-    delegator: AccAddress,
-    validator: ValAddress
+    delegator?: AccAddress,
+    validator?: ValAddress
   ): Promise<UnbondingDelegation> {
     return this.unbondingDelegations(delegator, validator).then(
       udelgs => udelgs[0]


### PR DESCRIPTION
The API states parameters are options for either delegator or validator, but implementation currently requires both. 