### PR TITLE
Fix JSON Parsing Error when WASM messages aren't proper JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -757,6 +757,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3796,6 +3797,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4641,6 +4643,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.6.1",
+  "version": "1.8.0",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/staking/Validator.spec.ts
+++ b/src/core/staking/Validator.spec.ts
@@ -17,6 +17,7 @@ describe('Validator', () => {
         website: 'https://www.westaking.io',
         details:
           'Delegate your luna to us for the staking rewards. We will do our best as secure and stable validator.',
+        security_contact: 'x@x.com',
       },
       unbonding_height: '0',
       unbonding_time: '1970-01-01T00:00:00Z',
@@ -45,6 +46,7 @@ describe('Validator', () => {
         website: 'https://www.westaking.io',
         details:
           'Delegate your luna to us for the staking rewards. We will do our best as secure and stable validator.',
+        security_contact: 'x@x.com',
       },
       unbonding_height: 0,
       unbonding_time: new Date('1970-01-01T00:00:00Z'),

--- a/src/core/wasm/msgs/MsgExecuteContract.spec.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.spec.ts
@@ -1,0 +1,21 @@
+import { MsgExecuteContract } from './MsgExecuteContract';
+
+describe('MsgExecuteContract', () => {
+  it('works when execute_msg is not JSON', () => {
+    const msg1 = MsgExecuteContract.fromData({
+      type: 'wasm/MsgExecuteContract',
+      value: {
+        sender: 'terra16xw94u0jgmuaz8zs54xn9x96lxew74gs05gs4h',
+        contract: 'terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6',
+        execute_msg:
+          'eyJ0cmFuc2ZlciI6eyJyZWNpcGllbnQiOnRlcnJhMTNqcWdydHF3dWN4NGpkdmhnMGQ0dGM4MDg5MmZzY3g1NDI5OHl0LCJhbW91bnQiOjEwMDAwfX0=',
+        coins: [],
+      },
+    });
+
+    expect(typeof msg1.execute_msg).toBe('string');
+    expect(msg1.execute_msg).toEqual(
+      'eyJ0cmFuc2ZlciI6eyJyZWNpcGllbnQiOnRlcnJhMTNqcWdydHF3dWN4NGpkdmhnMGQ0dGM4MDg5MmZzY3g1NDI5OHl0LCJhbW91bnQiOjEwMDAwfX0='
+    );
+  });
+});

--- a/src/util/contract.ts
+++ b/src/util/contract.ts
@@ -2,9 +2,11 @@ import { BlockTxBroadcastResult, isTxError } from '../client/lcd/api/TxAPI';
 import { TxInfo } from '../core/TxInfo';
 
 /**
+ * Serializes a JavaScript object to a Base64-encoded string. If the data passed is
+ * already a string, it will not be serialized and just return as-is.
  *
- * @param data string
- * @returns
+ * @param data object to encode
+ * @returns base64-encoded string
  */
 export function dictToB64(data: any): string {
   // if data is just a plain string, it was not valid Base64-encoded JSON so it could not be parsed
@@ -16,9 +18,11 @@ export function dictToB64(data: any): string {
 }
 
 /**
+ * Recovers a JavaScript object from a Base64-encoded JSON string. If an error is encountered
+ * while parsing, the string will not be converted and fail by returning the input as-is.
  *
  * @param data string
- * @returns
+ * @returns converted object
  */
 export function b64ToDict(data: string): any {
   try {

--- a/src/util/contract.ts
+++ b/src/util/contract.ts
@@ -1,12 +1,31 @@
 import { BlockTxBroadcastResult, isTxError } from '../client/lcd/api/TxAPI';
 import { TxInfo } from '../core/TxInfo';
 
+/**
+ *
+ * @param data string
+ * @returns
+ */
 export function dictToB64(data: any): string {
-  return Buffer.from(JSON.stringify(data)).toString('base64');
+  // if data is just a plain string, it was not valid Base64-encoded JSON so it could not be parsed
+  if (typeof data === 'string') {
+    return data;
+  } else {
+    return Buffer.from(JSON.stringify(data)).toString('base64');
+  }
 }
 
+/**
+ *
+ * @param data string
+ * @returns
+ */
 export function b64ToDict(data: string): any {
-  return JSON.parse(Buffer.from(data, 'base64').toString());
+  try {
+    return JSON.parse(Buffer.from(data, 'base64').toString());
+  } catch {
+    return data;
+  }
 }
 
 export function getCodeId(


### PR DESCRIPTION
Some Msg types have `fromData` function that provide the convenience of parsing Base64-encoded JSON strings into objects, such as `MsgExecuteContract`. However, it is not always the case these strings are proper; the node does not check that the argument to `execute_msg` be a valid JSON string.

Example: https://fcd.terra.dev/txs/8AFFBC576725244C405E48A5FEE3DF35D6934DBC779C6C17604985C88C82B496

This hotfix will just skip the parsing if it runs into an error (base-64 or JSON decoding) and keep the raw string.